### PR TITLE
vvv-37-vesting-contract-idea-1-linear-vesting-linear-penalty-based

### DIFF
--- a/test/vesting/LinearVestingWithLinearPenalty.unit.t.sol
+++ b/test/vesting/LinearVestingWithLinearPenalty.unit.t.sol
@@ -20,11 +20,11 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
 
         uint256 roundNumber = 1;
         uint256 startTimestamp = block.timestamp;
-        vestingContract.setVestingParams(roundNumber, startTimestamp, startTimestamp + VESTING_LENGTH, NON_PENALIZED_PROPORTIONS[0]);
+        vestingContract.setVestingParams(roundNumber, startTimestamp, VESTING_INTERVAL_DURATION, TOTAL_VESTING_INTERVALS, INTERVALS_BEFORE_CLIFF);
 
         roundNumber = 2;
         startTimestamp = block.timestamp;
-        vestingContract.setVestingParams(roundNumber, startTimestamp, startTimestamp + VESTING_LENGTH, NON_PENALIZED_PROPORTIONS[1]);
+        vestingContract.setVestingParams(roundNumber, startTimestamp, VESTING_INTERVAL_DURATION, TOTAL_VESTING_INTERVALS, INTERVALS_BEFORE_CLIFF);
 
         vm.stopPrank();
         generateUserAddressListAndDealEther();
@@ -45,7 +45,7 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
             4. claim remaining nominal claimable amount at t=1 == 250/1000 (0 nominal remains)
             5. confirm a total claimed amount of 725 +/- 0.1% to allow for some truncation error
      */
-    function testVestingFlowWithoutInitialUnpenalizedAmount() public {
+    function testVestingFlow() public {
         //1. get signature for total nominal claimable amount of 1000e18
         uint256 nominalTotalAmount = 1000e18;
         uint256 investmentRound = 1;
@@ -53,18 +53,18 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
 
         vm.startPrank(users[0], users[0]);
         //2. claim 1/2 of nominal claimable amount at t=0.5 == 250/500 (500 nominal remains)
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 5 / 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 5);
         uint256 thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount, investmentRound)/2;
         vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);
 
         //3. claim 1/2 of remaining nominal claimable amount at t=0.9 == 225/900 (250 nominal remains)
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 4 / 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 4);
         uint256 nominalClaimedTokens = vestingContract.claimedNominalTokens(users[0]);
         thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount - nominalClaimedTokens, investmentRound)/2;
         vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);
 
         //4. claim remaining nominal claimable amount at t=1 == 250/1000 (0 nominal remains)
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 1 / 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 1);
         nominalClaimedTokens = vestingContract.claimedNominalTokens(users[0]);
         thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount - nominalClaimedTokens, investmentRound);
         vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);
@@ -83,65 +83,7 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
 
         vm.stopPrank();
 
-    }   
-
-    /**
-        @dev should operate similarly to above with the difference of there being an initial unpenalized claim amount
-
-        1. user is allotted 1000 nominal tokens
-        2. 10% is unpenalized, 90% is penalized
-        3. user claims 500 nominal tokens at t=0.5
-        4. should see that 1000 - 100 - (400/0.5) nominal tokens are claimed, leaving 100 nominal tokens remaining
-        5. user claims 100 nominal tokens at t=1.0, a total of 600 nominal tokens are claimed
-        6. check total within 0.1% tolerance
-     */
-
-    function testVestingFlowWithInitialUnpenalizedAmount() public {
-        //1. get signature for total nominal claimable amount of 1000e18
-        uint256 nominalTotalAmount = 1000e18;
-        uint256 investmentRound = 2;
-        bytes memory signature = getSignature(users[0], nominalTotalAmount, investmentRound);
-
-        vm.startPrank(users[0], users[0]);
-        //2. claim 1/2 of nominal claimable amount - at t=0.5 == 500 total == 100 actual unpenalized==100 nominal, 400 actual penalized==800 nominal (100 nominal remains)
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 5 / 10);
-        uint256 thisClaimAmount = nominalTotalAmount/2; //500e18
-        vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);
-        
-        uint256 claimedActual1 = vestingContract.claimedActualTokens(users[0]);
-        uint256 claimedNominal1 = vestingContract.claimedNominalTokens(users[0]);
-        uint256 claimableNowCheck1 = vestingContract.nominalToActual(nominalTotalAmount - claimedNominal1, investmentRound);
-        emit log_named_uint("claimedActualTokens1 (unp. + pen.)", claimedActual1/1e18);
-        emit log_named_uint("claimedNominalTokens1 (unp. + pen.)", claimedNominal1/1e18);
-        emit log_named_uint("claimableNowCheck1", claimableNowCheck1/1e18);
-
-        //3. claim remaining nominal (100) at t>1
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 10);
-        uint256 nominalClaimedTokens = vestingContract.claimedNominalTokens(users[0]);
-        thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount - nominalClaimedTokens, investmentRound);
-        emit log_named_uint("thisClaimAmount", thisClaimAmount/1e18);
-        emit log_named_uint("nominalClaimedTokens", nominalClaimedTokens/1e18);
-
-        vestingContract.claim(msg.sender, thisClaimAmount, nominalTotalAmount, investmentRound, signature);
-
-        uint256 claimedActual2 = vestingContract.claimedActualTokens(users[0]);
-        uint256 claimedNominal2 = vestingContract.claimedNominalTokens(users[0]);
-        uint256 claimableNowCheck2 = vestingContract.nominalToActual(nominalTotalAmount - claimedNominal2, investmentRound);
-        emit log_named_uint("claimedActual2 (unp. + pen.)", claimedActual2/1e18);
-        emit log_named_uint("claimedNominal2 (unp. + pen.)", claimedNominal2/1e18);
-        emit log_named_uint("claimableNowCheck2", claimableNowCheck2/1e18);
-
-        //4. confirm a total claimed amount of ~600
-        uint256 expectedClaimedAmount = 600e18;
-        uint256 actualClaimedAmount = vestingContract.claimedActualTokens(users[0]);
-        emit log_named_uint("expectedClaimedAmount", expectedClaimedAmount);
-        emit log_named_uint("actualClaimedAmount", actualClaimedAmount);
-
-        assertTrue(
-            actualClaimedAmount > (expectedClaimedAmount * 999 / 1000) && 
-            actualClaimedAmount < (expectedClaimedAmount * 1001 / 1000)
-        );
-    }
+    }  
 
     /// @dev ensures that a user cannot claim more than their allotted amount in a single case. This should be tested more thoroughly
     function testFailClaimMoreAfterLimit() public {
@@ -152,12 +94,12 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
 
         vm.startPrank(users[0], users[0]);
         //2. claim 1/2 of nominal claimable amount - at t=0.5 == 500 total == 100 actual unpenalized==100 nominal, 400 actual penalized==800 nominal (100 nominal remains)
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 5 / 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 5);
         uint256 thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount, investmentRound); //500e18
         vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);
 
         //3. claim remaining nominal (100) at t>1
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 10);
         uint256 nominalClaimedTokens = vestingContract.claimedNominalTokens(users[0]);
         thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount, investmentRound);
 
@@ -174,7 +116,7 @@ contract LinearVestingWithLinearPenaltyUnitTests is LinearVestingWithLinearPenal
 
         vm.startPrank(users[0], users[0]);
 
-        advanceBlockNumberAndTimestampByTimestamp(VESTING_LENGTH * 10);
+        advanceBlockNumberAndTimestampByTimestamp(VESTING_INTERVAL_DURATION * 100);
         uint256 nominalClaimedTokens = vestingContract.claimedNominalTokens(users[0]);
         uint256 thisClaimAmount = vestingContract.nominalToActual(nominalTotalAmount - nominalClaimedTokens, investmentRound);
         vestingContract.claim(users[0], thisClaimAmount, nominalTotalAmount, investmentRound, signature);

--- a/test/vesting/LinearVestingWithLinearPenaltyBase.sol
+++ b/test/vesting/LinearVestingWithLinearPenaltyBase.sol
@@ -21,8 +21,9 @@ contract LinearVestingWithLinearPenaltyBase is Test {
     address signer = vm.addr(signerKey);
     uint256 chainid = 5;
 
-    uint256 VESTING_LENGTH = 100_000;
-    uint256[] NON_PENALIZED_PROPORTIONS = [0, 1000, 2000, 3000, 4000]; //testing "@TGE" claimable amounts without penalty
+    uint256 VESTING_INTERVAL_DURATION = 1000;
+    uint256 TOTAL_VESTING_INTERVALS = 10;
+    uint256 INTERVALS_BEFORE_CLIFF = 2;
 
     address[] public users = new address[](333);
     bool logging = false;


### PR DESCRIPTION
### Description

Added concept for linear vesting with linear penalty for claiming before the end of the vesting period

### Related Issue (if applicable)

small truncation errors when claiming at multiple points throughout the vesting period (<0.1% for 100_000 second vesting period)

continuous vesting (rather than weekly/monthly) for easier implementation

no tiers of vesting lengths/rates based on investment round yet - would need some more direction there

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
