### PR TITLE
vvv2-11-remove-redundant-owner-check

### DIFF
--- a/contracts/FundNFT_ERC721.sol
+++ b/contracts/FundNFT_ERC721.sol
@@ -40,7 +40,6 @@ contract VVV_FUND_ERC721 is ERC721, AccessControl, ReentrancyGuard, Pausable {
     error InvalidSignature();
     error MaxAllocationWouldBeExceeded();
     error MaxSupplyWouldBeExceeded();
-    error NotTokenOwner();
     error MaxPublicMintsWouldBeExceeded();
     error PublicMintNotStarted();
     error UnableToWithdraw();


### PR DESCRIPTION
### Description

Removed a redundant ownerOf check in `VVV_FUND_ERC721.mintByTradeIn` and the `NotTokenOwner()` error related to it.

### Related Issue (if applicable)

### Type of Change

- [x] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
