### PR TITLE
vvv120-correction: removed unchecked recasting vulnerability, input args set variable type

### DIFF
--- a/contracts/vesting/VVVVesting.sol
+++ b/contracts/vesting/VVVVesting.sol
@@ -159,9 +159,7 @@ contract VVVVesting is VVVAuthorizationRegistryChecker {
             revert AmountIsGreaterThanWithdrawable();
         }
 
-        unchecked {
-            vestingSchedule.tokenAmountWithdrawn += uint128(_tokenAmountToWithdraw);
-        }
+        vestingSchedule.tokenAmountWithdrawn += uint128(_tokenAmountToWithdraw);
 
         VVVToken.safeTransfer(_tokenDestination, _tokenAmountToWithdraw);
 


### PR DESCRIPTION
### Description

There was one problem in `VVVVesting:withdrawVestedTokens` where the input argument was defined as uint256, and the recasting to uint128 within the function happened in an unchecked block. That could lead to unexpected behavior / wraparound, so though it'd be best to avoid this.

@r00tail for clarity's sake with describing the inputs, I've come around on defining these uint sizes in the input args as well, not doing so was starting to annoy me after looking at things again lol

### Related Issue (if applicable)

VVV-120

### Type of Change

- [x] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
