### PR TITLE
vvv-97-add-support-for-arbitrary-erc-20-investment-tokens

### DIFF
--- a/test/vc/VVVVCInvestmentLedger.fuzz.sol
+++ b/test/vc/VVVVCInvestmentLedger.fuzz.sol
@@ -51,6 +51,7 @@ contract VVVVCInvestmentLedgerFuzzTests is VVVVCTestBase {
             kycAddress: _kycAddress,
             kycAddressAllocation: _kycAddressAllocation,
             amountToInvest: _amountToInvest,
+            exchangeRateNumerator: exchangeRateNumerator,
             deadline: _deadline,
             signature: bytes("placeholder")
         });

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -62,6 +62,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
         assertTrue(LedgerInstance.isSignatureValid(params));
@@ -77,6 +78,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -96,6 +98,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -119,6 +122,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -145,6 +149,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -175,6 +180,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -196,6 +202,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -228,6 +235,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -252,6 +260,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -53,6 +53,7 @@ abstract contract VVVVCTestBase is Test {
     //ledger contract-specific values
     bytes32 ledgerManagerRole = keccak256("LEDGER_MANAGER_ROLE");
     uint48 defaultAdminTransferDelay = 1 days;
+    uint256 exchangeRateNumerator = 1e6;
 
     //claim contract-specific values
     uint256 projectTokenAmountToProxyWallet = 1_000_000 * 1e18; //1 million tokens
@@ -139,6 +140,7 @@ abstract contract VVVVCTestBase is Test {
                         _params.paymentTokenAddress,
                         _params.kycAddress,
                         _params.kycAddressAllocation,
+                        _params.exchangeRateNumerator,
                         _params.deadline,
                         chainId
                     )
@@ -157,6 +159,7 @@ abstract contract VVVVCTestBase is Test {
         uint256 _investmentRoundLimit,
         uint256 _investmentAmount,
         uint256 _investmentAllocation,
+        uint256 _exchangeRateNumerator,
         address _kycAddress
     ) public view returns (VVVVCInvestmentLedger.InvestParams memory) {
         VVVVCInvestmentLedger.InvestParams memory params = VVVVCInvestmentLedger.InvestParams({
@@ -168,6 +171,7 @@ abstract contract VVVVCTestBase is Test {
             kycAddress: _kycAddress,
             kycAddressAllocation: _investmentAllocation,
             amountToInvest: _investmentAmount,
+            exchangeRateNumerator: _exchangeRateNumerator,
             deadline: block.timestamp + 1 hours,
             signature: bytes("placeholder")
         });
@@ -198,6 +202,7 @@ abstract contract VVVVCTestBase is Test {
                 investmentRoundSampleLimit,
                 _amountsToInvest[i],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             );
             investAsUser(_investor, investParams);

--- a/test/vc/VVVVCTokenDistributor.fuzz.t.sol
+++ b/test/vc/VVVVCTokenDistributor.fuzz.t.sol
@@ -95,6 +95,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
                     type(uint256).max, //sample very high round limit to avoid this error
                     testParams.tokenAmountsToInvest[i], // invested amounts
                     type(uint256).max, //sample very high allocation
+                    exchangeRateNumerator,
                     _kycAddress
                 )
             );
@@ -209,6 +210,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
                 type(uint256).max, //sample very high round limit to avoid this error
                 investedAmount, // invested amounts
                 type(uint256).max, //sample very high allocation
+                exchangeRateNumerator,
                 _caller
             )
         );

--- a/test/vc/VVVVCTokenDistributor.unit.t.sol
+++ b/test/vc/VVVVCTokenDistributor.unit.t.sol
@@ -110,6 +110,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -143,6 +144,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -195,6 +197,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -256,6 +259,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -299,6 +303,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -353,6 +358,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                     type(uint256).max, //ensuring no ExceedsAllocation error for this test
                     sampleAmountsToInvest[paymentTokenAmountIndex],
                     userPaymentTokenDefaultAllocation,
+                    exchangeRateNumerator,
                     thisInvestor
                 )
             );
@@ -400,6 +406,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 investmentAmount,
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );


### PR DESCRIPTION
adding exchange rate to target stablecoin so that investment in an arbitrary ERC20 is an option

### Description

Please provide a brief description of the changes you've made.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
