### PR TITLE
vvv-34-add-admin-functionality-to-investment-ledger

### DIFF
--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -24,6 +24,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     /// @notice The address authorized to sign investment transactions
     address public signer;
 
+    /// @notice flag to pause investments
+    bool public investmentIsPaused;
+
     /// @notice the denominator used to convert units of payment tokens to units of $STABLE (i.e. USDC/T)
     uint256 public exchangeRateDenominator = 1e6;
 
@@ -100,6 +103,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     /// @notice Error thrown when the signer address is not recovered from the provided signature
     error InvalidSignature();
 
+    /// @notice Error thrown when an attempt to invest is made while investment is paused
+    error InvestmentPaused();
+
     /**
         @notice stores the signer address and initializes the EIP-712 domain separator
         @param _signer The address authorized to sign investment transactions
@@ -128,6 +134,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
      * @param _params An InvestParams struct containing the investment parameters
      */
     function invest(InvestParams memory _params) external {
+        //check if investments are paused
+        if (investmentIsPaused) revert InvestmentPaused();
+
         // check if signature is valid
         if (!_isSignatureValid(_params)) {
             revert InvalidSignature();
@@ -262,5 +271,10 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
             _refundTokenAmount,
             _stablecoinEquivalent
         );
+    }
+
+    /// @notice admin function to pause investment
+    function setInvestmentIsPaused(bool _isPaused) external onlyAuthorized {
+        investmentIsPaused = _isPaused;
     }
 }

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -73,6 +73,24 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         uint256 investmentAmount
     );
 
+    /**
+     * @notice Event emitted when a VC investment is refunded
+     * @param userKycAddress The kyc address of the user to refund
+     * @param tokenDestination The address to which to send the refund token
+     * @param investmentRound The round of the investment to refund
+     * @param refundTokenAddress The address of the token to refund
+     * @param refundTokenAmount The amount of the token to refund
+     * @param stablecoinEquivalent The equivalent amount of stablecoin to the token amount refunded
+     */
+    event VCRefund(
+        address userKycAddress,
+        address tokenDestination,
+        uint256 investmentRound,
+        address refundTokenAddress,
+        uint256 refundTokenAmount,
+        uint256 stablecoinEquivalent
+    );
+
     /// @notice Error thrown when the caller or investment round allocation has been exceeded
     error ExceedsAllocation();
 
@@ -216,5 +234,33 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     ///@notice Allows admin to set the exchange rate denominator
     function setExchangeRateDenominator(uint256 _exchangeRateDenominator) external onlyAuthorized {
         exchangeRateDenominator = _exchangeRateDenominator;
+    }
+
+    /**
+        @notice refunds a user's investment in units of the specified ERC20 token
+        @dev ex. to refund user 1 $VVV which was invested at $10 per VVV, _refundTokenAmount = 1, _stablecoinEquivalent = 10
+        @dev allows erasing manually added investment records
+     */
+    function refundUserInvestment(
+        address _userKycAddress,
+        address _tokenDestination,
+        uint256 _investmentRound,
+        address _refundTokenAddress,
+        uint256 _refundTokenAmount,
+        uint256 _stablecoinEquivalent
+    ) external onlyAuthorized {
+        kycAddressInvestedPerRound[_userKycAddress][_investmentRound] -= _stablecoinEquivalent;
+        totalInvestedPerRound[_investmentRound] -= _stablecoinEquivalent;
+
+        IERC20(_refundTokenAddress).safeTransfer(_tokenDestination, _refundTokenAmount);
+
+        emit VCRefund(
+            _userKycAddress,
+            _tokenDestination,
+            _investmentRound,
+            _refundTokenAddress,
+            _refundTokenAmount,
+            _stablecoinEquivalent
+        );
     }
 }

--- a/test/vc/VVVVCInvestmentLedger.fuzz.sol
+++ b/test/vc/VVVVCInvestmentLedger.fuzz.sol
@@ -51,6 +51,7 @@ contract VVVVCInvestmentLedgerFuzzTests is VVVVCTestBase {
             kycAddress: _kycAddress,
             kycAddressAllocation: _kycAddressAllocation,
             amountToInvest: _amountToInvest,
+            exchangeRateNumerator: exchangeRateNumerator,
             deadline: _deadline,
             signature: bytes("placeholder")
         });

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -62,6 +62,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
         assertTrue(LedgerInstance.isSignatureValid(params));
@@ -77,6 +78,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -96,6 +98,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -119,6 +122,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -145,6 +149,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -175,6 +180,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -196,6 +202,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -228,6 +235,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 
@@ -252,6 +260,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             investmentRoundSampleLimit,
             sampleAmountsToInvest[0],
             userPaymentTokenDefaultAllocation,
+            exchangeRateNumerator,
             sampleKycAddress
         );
 

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -141,7 +141,6 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             sampleKycAddress
         );
         investAsUser(sampleUser, params);
-
         uint256 userInvested2 = LedgerInstance.kycAddressInvestedPerRound(
             sampleKycAddress,
             sampleInvestmentRoundIds[0]

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -53,6 +53,7 @@ abstract contract VVVVCTestBase is Test {
     //ledger contract-specific values
     bytes32 ledgerManagerRole = keccak256("LEDGER_MANAGER_ROLE");
     uint48 defaultAdminTransferDelay = 1 days;
+    uint256 exchangeRateNumerator = 1e6;
 
     //claim contract-specific values
     uint256 projectTokenAmountToProxyWallet = 1_000_000 * 1e18; //1 million tokens
@@ -139,6 +140,7 @@ abstract contract VVVVCTestBase is Test {
                         _params.paymentTokenAddress,
                         _params.kycAddress,
                         _params.kycAddressAllocation,
+                        _params.exchangeRateNumerator,
                         _params.deadline,
                         chainId
                     )
@@ -157,6 +159,7 @@ abstract contract VVVVCTestBase is Test {
         uint256 _investmentRoundLimit,
         uint256 _investmentAmount,
         uint256 _investmentAllocation,
+        uint256 _exchangeRateNumerator,
         address _kycAddress
     ) public view returns (VVVVCInvestmentLedger.InvestParams memory) {
         VVVVCInvestmentLedger.InvestParams memory params = VVVVCInvestmentLedger.InvestParams({
@@ -168,6 +171,7 @@ abstract contract VVVVCTestBase is Test {
             kycAddress: _kycAddress,
             kycAddressAllocation: _investmentAllocation,
             amountToInvest: _investmentAmount,
+            exchangeRateNumerator: _exchangeRateNumerator,
             deadline: block.timestamp + 1 hours,
             signature: bytes("placeholder")
         });
@@ -198,6 +202,7 @@ abstract contract VVVVCTestBase is Test {
                 investmentRoundSampleLimit,
                 _amountsToInvest[i],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             );
             investAsUser(_investor, investParams);

--- a/test/vc/VVVVCTokenDistributor.fuzz.t.sol
+++ b/test/vc/VVVVCTokenDistributor.fuzz.t.sol
@@ -95,6 +95,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
                     type(uint256).max, //sample very high round limit to avoid this error
                     testParams.tokenAmountsToInvest[i], // invested amounts
                     type(uint256).max, //sample very high allocation
+                    exchangeRateNumerator,
                     _kycAddress
                 )
             );
@@ -209,6 +210,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
                 type(uint256).max, //sample very high round limit to avoid this error
                 investedAmount, // invested amounts
                 type(uint256).max, //sample very high allocation
+                exchangeRateNumerator,
                 _caller
             )
         );

--- a/test/vc/VVVVCTokenDistributor.unit.t.sol
+++ b/test/vc/VVVVCTokenDistributor.unit.t.sol
@@ -110,6 +110,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -143,6 +144,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -195,6 +197,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -256,6 +259,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -299,6 +303,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 sampleAmountsToInvest[0],
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );
@@ -353,6 +358,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                     type(uint256).max, //ensuring no ExceedsAllocation error for this test
                     sampleAmountsToInvest[paymentTokenAmountIndex],
                     userPaymentTokenDefaultAllocation,
+                    exchangeRateNumerator,
                     thisInvestor
                 )
             );
@@ -400,6 +406,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
                 investmentRoundSampleLimit,
                 investmentAmount,
                 userPaymentTokenDefaultAllocation,
+                exchangeRateNumerator,
                 sampleKycAddress
             )
         );


### PR DESCRIPTION
### Description

Added:
1. The ability to pause all investments
2. The ability to create refund transactions (to refund any ERC20 and subtract the corresponding stablecoin amount from the ledger)
3. The ability to withdraw erroneously sent funds (ability is already present via `withdraw` function as of start of work on this PR)

For (2) above, given the uncertainties about the token used to send the refund, I left the refund function as flexible as possible so that these details can be determined off-chain.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
