### PR TITLE
vvv-126-optimize-eth-staking-storage-and-reward-claim

### DIFF
--- a/test/staking/VVVETHStaking.fuzz.t.sol
+++ b/test/staking/VVVETHStaking.fuzz.t.sol
@@ -75,14 +75,18 @@ contract VVVETHStakingUnitFuzzTests is VVVETHStakingTestBase {
         uint256 stakeId = EthStakingInstance.stakeEth{ value: _stakeAmount }(stakeDuration);
 
         (
+            address staker,
             uint224 stakedEthAmount,
             uint32 stakedTimestamp,
+            uint256 secondsClaimed,
             bool stakeIsWithdrawn,
             VVVETHStaking.StakingDuration stakedDuration
-        ) = EthStakingInstance.userStakes(caller, stakeId);
+        ) = EthStakingInstance.stakes(stakeId);
 
+        assert(staker == caller);
         assert(stakedEthAmount == _stakeAmount);
         assert(stakedTimestamp == block.timestamp);
+        assert(secondsClaimed == 0);
         assert(stakeIsWithdrawn == false);
         assert(stakedDuration == stakeDuration);
 
@@ -118,14 +122,17 @@ contract VVVETHStakingUnitFuzzTests is VVVETHStakingTestBase {
 
         // Verify the restake
         (
+            ,
             uint224 restakedEthAmount,
             uint32 restakedTimestamp,
+            uint256 secondsClaimed,
             bool restakeIsWithdrawn,
             VVVETHStaking.StakingDuration restakedDuration
-        ) = EthStakingInstance.userStakes(caller, newStakeId);
+        ) = EthStakingInstance.stakes(newStakeId);
 
         assert(restakedEthAmount == _stakeAmount);
         assert(restakedTimestamp >= block.timestamp);
+        assert(secondsClaimed == 0);
         assert(restakeIsWithdrawn == false);
         assert(restakedDuration == newStakeDuration);
 
@@ -149,7 +156,7 @@ contract VVVETHStakingUnitFuzzTests is VVVETHStakingTestBase {
 
         EthStakingInstance.withdrawStake(stakeId);
 
-        (, , bool stakeIsWithdrawn, ) = EthStakingInstance.userStakes(caller, stakeId);
+        (, , , , bool stakeIsWithdrawn, ) = EthStakingInstance.stakes(stakeId);
 
         assert(stakeIsWithdrawn == true);
 
@@ -158,43 +165,33 @@ contract VVVETHStakingUnitFuzzTests is VVVETHStakingTestBase {
 
     // Test that any amount < claimableVvv is claimable by the user after the stake duration elapses
     // also tests that the claimed + remaining claimable add up to originally claimable amount
-    function testFuzz_claimVvv(
-        uint256 _callerKey,
-        uint224 _stakeAmount,
-        uint8 _stakeDuration,
-        uint256 _claimAmount
-    ) public {
+    function testFuzz_claimVvv(uint256 _callerKey, uint224 _stakeAmount, uint8 _stakeDuration) public {
         uint256 callerKey = bound(_callerKey, 1, 100000);
         address caller = vm.addr(callerKey);
         uint8 stakeDuration = uint8(bound(_stakeDuration, 0, 2));
         vm.assume(caller != address(0));
         vm.assume(_stakeAmount != 0);
-        vm.assume(_claimAmount != 0);
         uint256 stakeAmount = bound(_stakeAmount, 1, 100 ether);
 
         vm.deal(caller, _stakeAmount);
         vm.startPrank(caller, caller);
 
         VVVETHStaking.StakingDuration stakeDurationEnum = VVVETHStaking.StakingDuration(stakeDuration);
-        EthStakingInstance.stakeEth{ value: stakeAmount }(stakeDurationEnum);
+        uint256 stakeId = EthStakingInstance.stakeEth{ value: stakeAmount }(stakeDurationEnum);
 
         advanceBlockNumberAndTimestampInSeconds(
             EthStakingInstance.durationToSeconds(stakeDurationEnum) + 1
         );
 
-        uint256 claimableVvv = EthStakingInstance.calculateClaimableVvvAmount();
-
-        // Ensure the claim amount is not more than what's available
-        vm.assume(_claimAmount <= claimableVvv);
+        uint256 claimableVvv = EthStakingInstance.calculateClaimableVvvAmount(stakeId);
 
         uint256 vvvBalanceBefore = VvvTokenInstance.balanceOf(caller);
-        EthStakingInstance.claimVvv(_claimAmount);
+        EthStakingInstance.claimVvv(stakeId);
         uint256 vvvBalanceAfter = VvvTokenInstance.balanceOf(caller);
 
-        uint256 claimableVvv2 = EthStakingInstance.calculateClaimableVvvAmount();
+        uint256 claimableVvv2 = EthStakingInstance.calculateClaimableVvvAmount(stakeId);
 
-        assertTrue(vvvBalanceAfter == vvvBalanceBefore + _claimAmount);
-        assertTrue(claimableVvv2 == claimableVvv - _claimAmount);
+        assertTrue(vvvBalanceAfter == vvvBalanceBefore + claimableVvv + claimableVvv2);
 
         vm.stopPrank();
     }

--- a/test/staking/VVVETHStaking.unit.t.sol
+++ b/test/staking/VVVETHStaking.unit.t.sol
@@ -575,8 +575,8 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
 
     // These are tested in the above tests as well, but I'm adding them here for showing explicit testing of these functions by name
 
-    // Tests the calculation of the accrued / claimable $VVV amount
-    function testCalculateClaimableVvvAmount() public {
+    // Tests the calculation of the accrued $VVV amount
+    function testCalculateAccruedVvvAmount() public {
         vm.startPrank(sampleUser, sampleUser);
         uint256 stakingDurationDivisor = 2;
         uint256 stakeEthAmount = 1 ether;
@@ -590,7 +590,7 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
                 stakingDurationDivisor) + 1
         );
 
-        uint256 accruedVvv = EthStakingInstance.calculateClaimableVvvAmount(stakeId);
+        uint256 accruedVvv = EthStakingInstance.calculateAccruedVvvAmount(stakeId);
 
         uint256 expectedAccruedVvv = (stakeEthAmount *
             EthStakingInstance.ethToVvvExchangeRate() *

--- a/test/staking/VVVETHStakingTestBase.sol
+++ b/test/staking/VVVETHStakingTestBase.sol
@@ -30,6 +30,8 @@ abstract contract VVVETHStakingTestBase is Test {
     bytes32 ethStakingManagerRole = keccak256("ETH_STAKING_MANAGER_ROLE");
     uint48 defaultAdminTransferDelay = 1 days;
 
+    uint256 errorMarginProportion = 1_000_000_000;
+
     function advanceBlockNumberAndTimestampInBlocks(uint256 blocks) public {
         blockNumber += blocks;
         blockTimestamp += blocks * 12; //seconds per block


### PR DESCRIPTION
### Description

Converting `VVVETHStaking` such that the storage layout is simplified - stakes are now only mapped to `stakeId` and not the staking user.

Some noteworthy changes to try to highlight since the first commit throws in a bunch of changes:
1. $VVV accrual and claim are in calculated internally in terms of "unclaimed seconds" within the staking period
2. View functions (`calculateAccruedVvvAmount` and `calculateClaimableVvvAmount`) are called on a per-stakeId basis now - API will document the associated user rather than relying on the on-chain storage for this.
3. A couple tests were removed entirely which related to a user-defined claimable $VVV amount (now full amount by default)

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
