### PR TITLE
vvv-132-fix-investment-ledger-type-hash

### DIFF
--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -17,7 +17,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         keccak256(bytes("EIP712Domain(string name,uint256 chainId,address verifyingContract)"));
     bytes32 public constant INVESTMENT_TYPEHASH =
         keccak256(
-            bytes("VCInvestment(uint256 investmentRound,address kycAddress,uint256 investmentAmount)")
+            bytes(
+                "VCInvestment(uint256 investmentRound,address paymentTokenAddress,address kycAddress,uint256 exchangeRateNumerator,uint256 exchangeRateDenominator,uint256 investmentAmount)"
+            )
         );
     bytes32 public immutable DOMAIN_SEPARATOR;
 


### PR DESCRIPTION
### Description

modified `INVESTMENT_TYPEHASH` definition to match latest `VCInvestment` event definition

### Related Issue (if applicable)

### Type of Change

- [x] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
