### PR TITLE
vvv-134-alternative-token-distributor-version

### DIFF
--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -18,7 +18,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     bytes32 public constant INVESTMENT_TYPEHASH =
         keccak256(
             bytes(
-                "InvestParams(uint256 investmentRound,uint256 investmentRoundLimit,uint256 investmentRoundStartTimestamp,uint256 investmentRoundEndTimestamp,address paymentTokenAddress,address kycAddress,uint256 kycAddressAllocation,uint256 amountToInvest,uint256 exchangeRateNumerator,uint256 deadline)"
+                "InvestParams(uint256 investmentRound,uint256 investmentRoundLimit,uint256 investmentRoundStartTimestamp,uint256 investmentRoundEndTimestamp,address paymentTokenAddress,address kycAddress,uint256 kycAddressAllocation,uint256 exchangeRateNumerator,uint256 deadline)"
             )
         );
     bytes32 public immutable DOMAIN_SEPARATOR;

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -18,7 +18,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     bytes32 public constant INVESTMENT_TYPEHASH =
         keccak256(
             bytes(
-                "VCInvestment(uint256 investmentRound,address paymentTokenAddress,address kycAddress,uint256 exchangeRateNumerator,uint256 exchangeRateDenominator,uint256 investmentAmount)"
+                "InvestParams(uint256 investmentRound,uint256 investmentRoundLimit,uint256 investmentRoundStartTimestamp,uint256 investmentRoundEndTimestamp,address paymentTokenAddress,address kycAddress,uint256 kycAddressAllocation,uint256 amountToInvest,uint256 exchangeRateNumerator,uint256 deadline)"
             )
         );
     bytes32 public immutable DOMAIN_SEPARATOR;

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -17,7 +17,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         keccak256(bytes("EIP712Domain(string name,uint256 chainId,address verifyingContract)"));
     bytes32 public constant INVESTMENT_TYPEHASH =
         keccak256(
-            bytes("VCInvestment(uint256 investmentRound,address kycAddress,uint256 investmentAmount)")
+            bytes(
+                "VCInvestment(uint256 investmentRound,address paymentTokenAddress,address kycAddress,uint256 exchangeRateNumerator,uint256 exchangeRateDenominator,uint256 investmentAmount)"
+            )
         );
     bytes32 public immutable DOMAIN_SEPARATOR;
 

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -220,8 +220,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
                         _params.kycAddress,
                         _params.kycAddressAllocation,
                         _params.exchangeRateNumerator,
-                        _params.deadline,
-                        block.chainid
+                        _params.deadline
                     )
                 )
             )

--- a/contracts/vc/VVVVCTokenDistributor.sol
+++ b/contracts/vc/VVVVCTokenDistributor.sol
@@ -201,8 +201,7 @@ contract VVVVCTokenDistributor {
                         _params.projectTokenAddress,
                         _params.projectTokenProxyWallets,
                         _params.investmentRoundIds,
-                        _params.deadline,
-                        block.chainid
+                        _params.deadline
                     )
                 )
             )

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -46,7 +46,6 @@ abstract contract VVVVCTestBase is Test {
 
     uint256 blockNumber;
     uint256 blockTimestamp;
-    uint256 chainId = 31337; //test chain id - leave this alone
 
     string environmentTag = "development";
 
@@ -141,8 +140,7 @@ abstract contract VVVVCTestBase is Test {
                         _params.kycAddress,
                         _params.kycAddressAllocation,
                         _params.exchangeRateNumerator,
-                        _params.deadline,
-                        chainId
+                        _params.deadline
                     )
                 )
             )
@@ -226,8 +224,7 @@ abstract contract VVVVCTestBase is Test {
                         _params.projectTokenAddress,
                         _params.projectTokenProxyWallets,
                         _params.investmentRoundIds,
-                        _params.deadline,
-                        chainId
+                        _params.deadline
                     )
                 )
             )


### PR DESCRIPTION
### Description

Create alternate token distributor which relies on Merkle proof validation of prior investment rather than reading investment history directly on the main investment ledger.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests passed
