### PR TITLE
VVV-130 ETH staking improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ out
 
 broadcast
 lib
+scripts

--- a/contracts/staking/VVVETHStaking.sol
+++ b/contracts/staking/VVVETHStaking.sol
@@ -56,8 +56,13 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
     ///@notice emitted when ETH is received
     event EtherReceived();
 
-    ///@notice emitted when admin withdraws ETH
-    event EtherWithdrawn();
+    ///@notice emitted when admin withdraws ETH. Contains subset of internal transaction data
+    // to make internal transaction lookups not necessary.
+    event EtherWithdrawn(
+        address indexed from,
+        address indexed to,
+        uint256 amount
+    );
 
     ///@notice emitted when a user stakes
     event Stake(
@@ -281,7 +286,7 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
     function withdrawEth(uint256 _amount) external onlyAuthorized {
         (bool success, ) = payable(msg.sender).call{ value: _amount }("");
         if (!success) revert WithdrawFailed();
-        emit EtherWithdrawn();
+        emit EtherWithdrawn(address(this), msg.sender, _amount);
     }
 
     ///@notice withdraws VVV tokens from the contract

--- a/contracts/staking/VVVETHStaking.sol
+++ b/contracts/staking/VVVETHStaking.sol
@@ -58,11 +58,7 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
 
     ///@notice emitted when admin withdraws ETH. Contains subset of internal transaction data
     // to make internal transaction lookups not necessary.
-    event EtherWithdrawn(
-        address indexed from,
-        address indexed to,
-        uint256 amount
-    );
+    event EtherWithdrawn(address indexed from, address indexed to, uint256 amount);
 
     ///@notice emitted when a user stakes
     event Stake(
@@ -155,8 +151,17 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
         StakingDuration _stakeDuration
     ) external whenStakingIsPermitted returns (uint256) {
         StakeData storage stake = stakes[_stakeId];
+
         _withdrawChecks(stake);
         stake.stakeIsWithdrawn = true;
+        emit Withdraw(
+            msg.sender,
+            _stakeId,
+            stake.stakedEthAmount,
+            stake.stakeStartTimestamp,
+            stake.stakeDuration
+        );
+
         _stakeEth(_stakeDuration, stake.stakedEthAmount);
         return stakeId;
     }

--- a/contracts/staking/VVVETHStaking.sol
+++ b/contracts/staking/VVVETHStaking.sol
@@ -56,6 +56,9 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
     ///@notice emitted when ETH is received
     event EtherReceived();
 
+    ///@notice emitted when admin withdraws ETH
+    event EtherWithdrawn();
+
     ///@notice emitted when a user stakes
     event Stake(
         address indexed staker,
@@ -278,6 +281,7 @@ contract VVVETHStaking is VVVAuthorizationRegistryChecker {
     function withdrawEth(uint256 _amount) external onlyAuthorized {
         (bool success, ) = payable(msg.sender).call{ value: _amount }("");
         if (!success) revert WithdrawFailed();
+        emit EtherWithdrawn();
     }
 
     ///@notice withdraws VVV tokens from the contract

--- a/test/staking/VVVETHStaking.unit.t.sol
+++ b/test/staking/VVVETHStaking.unit.t.sol
@@ -801,6 +801,8 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
         uint256 userBalanceBefore = address(ethStakingManager).balance;
 
         vm.startPrank(ethStakingManager, ethStakingManager);
+        vm.expectEmit(address(EthStakingInstance));
+        emit VVVETHStaking.EtherWithdrawn();
         EthStakingInstance.withdrawEth(stakeEthAmount);
         vm.stopPrank();
 

--- a/test/staking/VVVETHStaking.unit.t.sol
+++ b/test/staking/VVVETHStaking.unit.t.sol
@@ -802,7 +802,11 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
 
         vm.startPrank(ethStakingManager, ethStakingManager);
         vm.expectEmit(address(EthStakingInstance));
-        emit VVVETHStaking.EtherWithdrawn();
+        emit VVVETHStaking.EtherWithdrawn(
+            address(EthStakingInstance),
+            ethStakingManager,
+            stakeEthAmount
+        );
         EthStakingInstance.withdrawEth(stakeEthAmount);
         vm.stopPrank();
 

--- a/test/staking/VVVETHStaking.unit.t.sol
+++ b/test/staking/VVVETHStaking.unit.t.sol
@@ -802,11 +802,7 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
 
         vm.startPrank(ethStakingManager, ethStakingManager);
         vm.expectEmit(address(EthStakingInstance));
-        emit VVVETHStaking.EtherWithdrawn(
-            address(EthStakingInstance),
-            ethStakingManager,
-            stakeEthAmount
-        );
+        emit VVVETHStaking.EtherWithdrawn(address(EthStakingInstance), ethStakingManager, stakeEthAmount);
         EthStakingInstance.withdrawEth(stakeEthAmount);
         vm.stopPrank();
 
@@ -844,12 +840,13 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
         vm.stopPrank();
     }
 
-    // Tests that the Stake event is emitted correctly on restakes
-    function testEmitStakeRestake() public {
+    // Tests that the Withdrawn and Stake event is emitted correctly on restakes
+    function testEmitWithdrawAndStakeRestake() public {
         vm.startPrank(sampleUser, sampleUser);
         uint256 stakeId = 1;
         uint256 restakeId = stakeId + 1;
         uint256 stakedEthAmount = 1 ether;
+        uint256 stakeStartTimestamp = block.timestamp;
         VVVETHStaking.StakingDuration stakeDuration = VVVETHStaking.StakingDuration.ThreeMonths;
         EthStakingInstance.stakeEth{ value: 1 ether }(stakeDuration);
 
@@ -860,6 +857,13 @@ contract VVVETHStakingUnitTests is VVVETHStakingTestBase {
         uint256 restakeStartTimestamp = block.timestamp;
 
         vm.expectEmit(address(EthStakingInstance));
+        emit VVVETHStaking.Withdraw(
+            sampleUser,
+            stakeId,
+            stakedEthAmount,
+            uint32(stakeStartTimestamp),
+            stakeDuration
+        );
         emit VVVETHStaking.Stake(
             sampleUser,
             restakeId,


### PR DESCRIPTION
## Description
* Makes prettier ignore a folder used for uncommitted scripts to interact with the deployed contracts
* Emits `Withdraw` when restaking otherwise:
    * The previous staked will never be marked as withdrawn
    * The new stake appears to add value (ETH) to the contract, which it doesn't
* Adds the `EtherWithdrawn` event emitted when the admin withdraws ETH. This enables the indexing of these transactions. A subset of the internal transaction data is added to the event as it's not easily possible to read the internal transaction in the subgraph. 

## Dependencies
_Are there any dependencies to pull requests in other repositories? If so please provide links to these pull requests here._

*

## Additional notes
Not the only PR for this issue.
