### PR TITLE
vvv-137-node-contract-linear-vesting-schedule-yield

### DIFF
--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -5,18 +5,36 @@ import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { ERC721URIStorage } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
 contract VVVNodes is ERC721, ERC721URIStorage {
+    ///@notice Additional data for each token
+    struct TokenData {
+        //Remaining tokens to be vested, starts at 60% of $VVV initially locked in each node
+        uint256 unvestedAmount;
+        //timestamp of most recent token activation
+        uint256 vestingSince;
+        //claimable $VVV across vesting, transaction, and launchpad yield sources
+        uint256 claimableAmount;
+        //amount of $VVV to vest per second
+        uint256 amountToVestPerSecond;
+    }
+
     ///@notice The total number of nodes that can be minted
     uint256 public constant TOTAL_SUPPLY = 5000;
 
+    ///@notice The timestamp assigned to signify that vesting is paused for a node
+    uint256 public constant VESTING_INACTIVE_TIMESTAMP = type(uint32).max;
+
     ///@notice The current tokenId
     uint256 public tokenId;
+
+    ///@notice Maps a TokenData struct to each tokenId
+    mapping(uint256 => TokenData) public tokenData;
 
     ///@notice Thrown when a mint is attempted past the total supply
     error MaxSupplyReached();
 
     constructor() ERC721("Multi-token Nodes", "NODES") {}
 
-    ///@notice Mints a node to the recipient
+    ///@notice Mints a node to the recipient (placeholder)
     function mint(address _recipient) public {
         ++tokenId;
         if (tokenId > TOTAL_SUPPLY) revert MaxSupplyReached();
@@ -24,7 +42,7 @@ contract VVVNodes is ERC721, ERC721URIStorage {
         _mint(_recipient, tokenId);
     }
 
-    ///@notice sets token URI for token of tokenId
+    ///@notice Sets token URI for token of tokenId (placeholder)
     function setTokenURI(uint256 _tokenId, string calldata _tokenURI) public {
         _setTokenURI(_tokenId, _tokenURI);
     }
@@ -41,5 +59,44 @@ contract VVVNodes is ERC721, ERC721URIStorage {
         bytes4 _interfaceId
     ) public view override(ERC721, ERC721URIStorage) returns (bool) {
         return super.supportsInterface(_interfaceId);
+    }
+
+    ///@notice activates a node (starts vesting)
+    function _activateNode(uint256 _tokenId) private {
+        TokenData storage token = tokenData[_tokenId];
+        token.vestingSince = block.timestamp;
+    }
+
+    ///@notice deactivates a node (updates claimable tokens and pauses vesting)
+    function _deactivateNode(uint256 _tokenId) private {
+        TokenData storage token = tokenData[_tokenId];
+        _updateClaimableFromVesting(token);
+        token.vestingSince = VESTING_INACTIVE_TIMESTAMP;
+    }
+
+    ///@notice utilized in claiming and deactivation, updates the claimable tokens accumulated from vesting
+    function _updateClaimableFromVesting(TokenData storage _tokenData) private {
+        uint256 currentVestedAmount = _calculateVestedTokens(_tokenData);
+
+        _tokenData.unvestedAmount -= currentVestedAmount;
+        _tokenData.claimableAmount += currentVestedAmount;
+    }
+
+    ///@notice calculates vested tokens for a given tokenId since the last timestamp (vestingSince) update (does not account for claimed)
+    function _calculateVestedTokens(TokenData memory _tokenData) private view returns (uint256) {
+        uint256 vestingSince = _tokenData.vestingSince;
+
+        //if node is inactive, return 0 (no vesting will occur between time of deactivation and time at which this function is called while the node is still inactive)
+        if (vestingSince == VESTING_INACTIVE_TIMESTAMP) return 0;
+
+        uint256 unvestedAmount = _tokenData.unvestedAmount;
+        uint256 amountToVestPerSecond = _tokenData.amountToVestPerSecond;
+
+        uint256 currentVestedAmount = unvestedAmount >
+            (block.timestamp - vestingSince) * amountToVestPerSecond
+            ? (block.timestamp - vestingSince) * amountToVestPerSecond
+            : unvestedAmount;
+
+        return currentVestedAmount;
     }
 }

--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -1,0 +1,40 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import { ERC721URIStorage } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+
+contract VVVNodes is ERC721, ERC721URIStorage {
+    ///@notice The total number of nodes that can be minted
+    uint256 public constant TOTAL_SUPPLY = 5000;
+
+    ///@notice The current tokenId
+    uint256 public tokenId;
+
+    ///@notice Thrown when a mint is attempted past the total supply
+    error MaxSupplyReached();
+
+    constructor() ERC721("Multi-token Nodes", "NODES") {}
+
+    ///@notice Mints a node to the recipient
+    function mint(address _recipient) public {
+        ++tokenId;
+        if (tokenId > TOTAL_SUPPLY) revert MaxSupplyReached();
+
+        _mint(_recipient, tokenId);
+    }
+
+    ///@notice Returns the tokenURI for the given tokenId, required override
+    function tokenURI(
+        uint256 _tokenId
+    ) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+        return super.tokenURI(_tokenId);
+    }
+
+    ///@notice Returns whether the given interfaceId is supported, required override
+    function supportsInterface(
+        bytes4 _interfaceId
+    ) public view override(ERC721, ERC721URIStorage) returns (bool) {
+        return super.supportsInterface(_interfaceId);
+    }
+}

--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -24,6 +24,11 @@ contract VVVNodes is ERC721, ERC721URIStorage {
         _mint(_recipient, tokenId);
     }
 
+    ///@notice sets token URI for token of tokenId
+    function setTokenURI(uint256 _tokenId, string calldata _tokenURI) public {
+        _setTokenURI(_tokenId, _tokenURI);
+    }
+
     ///@notice Returns the tokenURI for the given tokenId, required override
     function tokenURI(
         uint256 _tokenId

--- a/test/nodes/VVVNodes.unit.t.sol
+++ b/test/nodes/VVVNodes.unit.t.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { VVVNodes } from "contracts/nodes/VVVNodes.sol";
+import { VVVNodesTestBase } from "./VVVNodesTestBase.sol";
+
+contract VVVNodesUnitTest is VVVNodesTestBase {
+    function setUp() public {
+        vm.startPrank(deployer, deployer);
+        NodesInstance = new VVVNodes();
+        vm.stopPrank();
+    }
+
+    function testDeployment() public {
+        assertNotEq(address(NodesInstance), address(0));
+    }
+
+    //tests that mint works
+    function testMint() public {
+        vm.startPrank(sampleUser, sampleUser);
+        NodesInstance.mint(sampleUser);
+        vm.stopPrank();
+        assertEq(NodesInstance.balanceOf(sampleUser), 1);
+    }
+}

--- a/test/nodes/VVVNodes.unit.t.sol
+++ b/test/nodes/VVVNodes.unit.t.sol
@@ -22,4 +22,15 @@ contract VVVNodesUnitTest is VVVNodesTestBase {
         vm.stopPrank();
         assertEq(NodesInstance.balanceOf(sampleUser), 1);
     }
+
+    //tests setting tokenURI for a tokenId
+    function testSetTokenURI() public {
+        vm.startPrank(deployer, deployer);
+        NodesInstance.mint(deployer);
+        vm.stopPrank();
+        vm.startPrank(deployer, deployer);
+        NodesInstance.setTokenURI(1, "https://example.com/token/1");
+        vm.stopPrank();
+        assertEq(NodesInstance.tokenURI(1), "https://example.com/token/1");
+    }
 }

--- a/test/nodes/VVVNodesTestBase.sol
+++ b/test/nodes/VVVNodesTestBase.sol
@@ -1,0 +1,32 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Test } from "lib/forge-std/src/Test.sol";
+import { VVVNodes } from "contracts/nodes/VVVNodes.sol";
+
+abstract contract VVVNodesTestBase is Test {
+    VVVNodes NodesInstance;
+
+    uint256 deployerKey = 1234;
+    uint256 sampleUserKey = 1234567;
+
+    address deployer = vm.addr(deployerKey);
+    address sampleUser = vm.addr(sampleUserKey);
+
+    uint256 blockNumber;
+    uint256 blockTimestamp;
+
+    function advanceBlockNumberAndTimestampInBlocks(uint256 blocks) public {
+        blockNumber += blocks;
+        blockTimestamp += blocks * 12; //seconds per block
+        vm.warp(blockTimestamp);
+        vm.roll(blockNumber);
+    }
+
+    function advanceBlockNumberAndTimestampInSeconds(uint256 secondsToAdvance) public {
+        blockNumber += secondsToAdvance / 12; //seconds per block
+        blockTimestamp += secondsToAdvance;
+        vm.warp(blockTimestamp);
+        vm.roll(blockNumber);
+    }
+}


### PR DESCRIPTION
### Description

Adding means to track token vesting and user's claimable tokens (which will be in the end from vesting, transaction, and launchpad yield) 

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests passed
