### PR TITLE
vvv-158-investment-ledger-immutable-conversion-rate-denominator

### DIFF
--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -30,7 +30,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     bool public investmentIsPaused;
 
     /// @notice the denominator used to convert units of payment tokens to units of $STABLE (i.e. USDC/T)
-    uint256 public immutable exchangeRateDenominator = 1e6;
+    uint256 public immutable exchangeRateDenominator;
 
     /// @notice stores kyc address amounts invested for each investment round
     mapping(address => mapping(uint256 => uint256)) public kycAddressInvestedPerRound;
@@ -118,6 +118,8 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         @notice stores the signer address and initializes the EIP-712 domain separator
         @param _signer The address authorized to sign investment transactions
         @param _environmentTag The environment tag for the EIP-712 domain separator
+        @param _authorizationRegistryAddress The address of the authorization registry
+        @param _exchangeRateDenominator The denominator used to convert units of payment tokens to units of $STABLE
      */
     constructor(
         address _signer,

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -30,7 +30,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     bool public investmentIsPaused;
 
     /// @notice the denominator used to convert units of payment tokens to units of $STABLE (i.e. USDC/T)
-    uint256 public exchangeRateDenominator = 1e6;
+    uint256 public immutable exchangeRateDenominator = 1e6;
 
     /// @notice stores kyc address amounts invested for each investment round
     mapping(address => mapping(uint256 => uint256)) public kycAddressInvestedPerRound;
@@ -122,9 +122,11 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     constructor(
         address _signer,
         string memory _environmentTag,
-        address _authorizationRegistryAddress
+        address _authorizationRegistryAddress,
+        uint256 _exchangeRateDenominator
     ) VVVAuthorizationRegistryChecker(_authorizationRegistryAddress) {
         signer = _signer;
+        exchangeRateDenominator = _exchangeRateDenominator;
 
         // EIP-712 domain separator
         DOMAIN_SEPARATOR = keccak256(
@@ -255,11 +257,6 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         kycAddressInvestedPerRound[_kycAddress][_investmentRound] += _amountToInvest;
         totalInvestedPerRound[_investmentRound] += _amountToInvest;
         emit VCInvestment(_investmentRound, address(0), _kycAddress, 0, 0, _amountToInvest);
-    }
-
-    ///@notice Allows admin to set the exchange rate denominator
-    function setExchangeRateDenominator(uint256 _exchangeRateDenominator) external onlyAuthorized {
-        exchangeRateDenominator = _exchangeRateDenominator;
     }
 
     /**

--- a/test/vc/VVVVCInvestmentLedger.fuzz.sol
+++ b/test/vc/VVVVCInvestmentLedger.fuzz.sol
@@ -19,7 +19,12 @@ contract VVVVCInvestmentLedgerFuzzTests is VVVVCTestBase {
         PaymentTokenInstance = new MockERC20(6); //usdc has 6 decimals
 
         //deploy ledger with placeholder, as no testing of call permissions are tested in this file
-        LedgerInstance = new VVVVCInvestmentLedger(testSigner, environmentTag, address(0));
+        LedgerInstance = new VVVVCInvestmentLedger(
+            testSigner,
+            environmentTag,
+            address(0),
+            exchangeRateDenominator
+        );
         ledgerDomainSeparator = LedgerInstance.DOMAIN_SEPARATOR();
         investmentTypehash = LedgerInstance.INVESTMENT_TYPEHASH();
 

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -64,6 +64,7 @@ abstract contract VVVVCTestBase is Test {
     bytes32 ledgerManagerRole = keccak256("LEDGER_MANAGER_ROLE");
     uint48 defaultAdminTransferDelay = 1 days;
     uint256 exchangeRateNumerator = 1e6;
+    uint256 exchangeRateDenominator = 1e6;
 
     //claim contract-specific values
     uint256 projectTokenAmountToProxyWallet = 1_000_000 * 1e18; //1 million tokens

--- a/test/vc/VVVVCTokenDistributor.fuzz.t.sol
+++ b/test/vc/VVVVCTokenDistributor.fuzz.t.sol
@@ -18,7 +18,12 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
         vm.startPrank(deployer, deployer);
 
         //placeholder address(0) for VVVAuthorizationRegistry
-        LedgerInstance = new VVVVCInvestmentLedger(testSigner, environmentTag, address(0));
+        LedgerInstance = new VVVVCInvestmentLedger(
+            testSigner,
+            environmentTag,
+            address(0),
+            exchangeRateDenominator
+        );
         ledgerDomainSeparator = LedgerInstance.DOMAIN_SEPARATOR();
         investmentTypehash = LedgerInstance.INVESTMENT_TYPEHASH();
 

--- a/test/vc/VVVVCTokenDistributor.unit.t.sol
+++ b/test/vc/VVVVCTokenDistributor.unit.t.sol
@@ -17,7 +17,12 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
         vm.startPrank(deployer, deployer);
 
         //placeholder address(0) for VVVAuthorizationRegistry
-        LedgerInstance = new VVVVCInvestmentLedger(testSigner, environmentTag, address(0));
+        LedgerInstance = new VVVVCInvestmentLedger(
+            testSigner,
+            environmentTag,
+            address(0),
+            exchangeRateDenominator
+        );
         ledgerDomainSeparator = LedgerInstance.DOMAIN_SEPARATOR();
         investmentTypehash = LedgerInstance.INVESTMENT_TYPEHASH();
 


### PR DESCRIPTION
### Description

made `exchangeRateDenominator` in `VVVVCInvestmentLedger` immutable, added a constructor argument to set this variable, and removed the setter for this function as well as related tests.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [x] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
