### PR TITLE
vvv-159-incorrect-claim-typehash

### DIFF
--- a/contracts/vc/VVVVCTokenDistributor.sol
+++ b/contracts/vc/VVVVCTokenDistributor.sol
@@ -17,7 +17,7 @@ contract VVVVCTokenDistributor {
     bytes32 public constant CLAIM_TYPEHASH =
         keccak256(
             bytes(
-                "ClaimParams(address callerAddress,address userKycAddress,address projectTokenAddress,address[] projectTokenProxyWallets,uint256[] investmentRoundIds,uint256 tokenAmountToClaim,uint256 deadline)"
+                "ClaimParams(address callerAddress,address userKycAddress,address projectTokenAddress,address[] projectTokenProxyWallets,uint256[] investmentRoundIds,uint256 deadline)"
             )
         );
     bytes32 public immutable DOMAIN_SEPARATOR;


### PR DESCRIPTION
### Description

removed `tokenAmountToClaim` from `CLAIM_TYPEHASH` in `VVVVCTokenDistributor`

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests passed
