### PR TITLE
vvv-165-alternate-token-distributor-contract-fix-intermittent-fuzz

### DIFF
--- a/test/vc/VVVVCAlternateTokenDistributor.fuzz.t.sol
+++ b/test/vc/VVVVCAlternateTokenDistributor.fuzz.t.sol
@@ -67,12 +67,17 @@ contract VVVVCAlternateTokenDistributorFuzzTests is VVVVCTestBase {
             _kycAddress
         );
 
+        uint256 callerBalanaceBeforeClaim = ProjectTokenInstance.balanceOf(params.callerAddress);
+
         vm.startPrank(_callerAddress, _callerAddress);
         AlternateTokenDistributorInstance.claim(params);
         vm.stopPrank();
 
+        uint256 balanceDifference = ProjectTokenInstance.balanceOf(params.callerAddress) -
+            callerBalanaceBeforeClaim;
+
         //check that the project token was withdrawn from the proxy wallet to the caller address
-        assertEq(params.tokenAmountToClaim, ProjectTokenInstance.balanceOf(params.callerAddress));
+        assertEq(params.tokenAmountToClaim, balanceDifference);
     }
 
     /**


### PR DESCRIPTION
### Description
Made a minor change to `VVVVCAlternateTokenDistributor.fuzz.t.sol:testFuzz_ClaimSuccess` to prevent intermittent failures when an address with a prior token balance claimed tokens.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [x] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
