### PR TITLE
VVV-169 unlock transaction processing yield event

### DIFF
--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -129,6 +129,13 @@ contract VVVNodes is ERC721, VVVAuthorizationRegistryChecker {
         );
 
         _mint(_recipient, tokenId);
+        emit Mint(
+            tokenId,
+            _recipient,
+            unvestedAmount,
+            lockedTransactionProcessingYield,
+            amountToVestPerSecond
+        );
     }
 
     ///@notice Stakes $VVV, handles activation if amount added causes total staked to surpass activation threshold

--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -250,6 +250,7 @@ contract VVVNodes is ERC721, VVVAuthorizationRegistryChecker {
 
             thisToken.lockedTransactionProcessingYield -= yieldToUnlock;
             thisToken.claimableAmount += yieldToUnlock;
+            emit UnlockTransactionProcessingYield(thisTokenId, yieldToUnlock);
         }
     }
 

--- a/contracts/nodes/VVVNodes.sol
+++ b/contracts/nodes/VVVNodes.sol
@@ -55,6 +55,18 @@ contract VVVNodes is ERC721, VVVAuthorizationRegistryChecker {
     ///@notice Emitted when $VVV is unstaked
     event Unstake(uint256 indexed tokenId, uint256 amount);
 
+    ///@notice Emitted when some transaction processing yield is unlocked
+    event UnlockTransactionProcessingYield(uint256 indexed tokenId, uint256 unlockedAmount);
+
+    ///@notice Emitted when node is minted
+    event Mint(
+        uint256 indexed tokenId,
+        address indexed recipient,
+        uint256 unvestedAmount,
+        uint256 lockedTransactionProcessingYield,
+        uint256 amountToVestPerSecond
+    );
+
     ///@notice Thrown when input array lengths are not matched
     error ArrayLengthMismatch();
 

--- a/test/nodes/VVVNodes.unit.t.sol
+++ b/test/nodes/VVVNodes.unit.t.sol
@@ -659,6 +659,10 @@ contract VVVNodesUnitTest is VVVNodesTestBase {
         vm.deal(address(NodesInstance), amountToUnlockPerNode * nodesToMint);
 
         uint256 gasLeftBefore = gasleft();
+        vm.expectEmit(address(NodesInstance));
+        for (uint256 i = 0; i < nodesToMint; ++i) {
+            emit VVVNodes.UnlockTransactionProcessingYield(i + 1, amountToUnlockPerNode);
+        }
         NodesInstance.unlockTransactionProcessingYield(tokenIds, amountToUnlockPerNode);
         uint256 gasUsed = gasLeftBefore - gasleft();
         vm.stopPrank();

--- a/test/nodes/VVVNodes.unit.t.sol
+++ b/test/nodes/VVVNodes.unit.t.sol
@@ -29,6 +29,15 @@ contract VVVNodesUnitTest is VVVNodesTestBase {
         uint256 lockedTransactionProcessingYield = sampleLockedTokens - unvestedAmount;
         uint256 amountToVestPerSecond = unvestedAmount / NodesInstance.VESTING_DURATION();
 
+        vm.expectEmit(address(NodesInstance));
+        emit VVVNodes.Mint(
+            1,
+            sampleUser,
+            unvestedAmount,
+            lockedTransactionProcessingYield,
+            amountToVestPerSecond
+        );
+
         NodesInstance.adminMint(sampleUser, sampleLockedTokens);
         vm.stopPrank();
 


### PR DESCRIPTION
### Description
Adds `Mint` and `UnlockTransactionProcessingYield` events + assertions. Used to track the locked transaction processing yield for each node in a subgraph.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
