### PR TITLE
VVV-339 EIP-712 improvement

### DIFF
--- a/contracts/vc/VVVVCTokenDistributor.sol
+++ b/contracts/vc/VVVVCTokenDistributor.sol
@@ -164,8 +164,8 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
                         CLAIM_TYPEHASH,
                         _params.kycAddress,
                         _params.projectTokenAddress,
-                        _params.projectTokenProxyWallets,
-                        _params.tokenAmountsToClaim,
+                        keccak256(abi.encodePacked(_params.projectTokenProxyWallets)),
+                        keccak256(abi.encodePacked(_params.tokenAmountsToClaim)),
                         _params.nonce,
                         _params.deadline
                     )

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -238,8 +238,8 @@ abstract contract VVVVCTestBase is Test {
                         _claimTypehash,
                         _params.kycAddress,
                         _params.projectTokenAddress,
-                        _params.projectTokenProxyWallets,
-                        _params.tokenAmountsToClaim,
+                        keccak256(abi.encodePacked(_params.projectTokenProxyWallets)),
+                        keccak256(abi.encodePacked(_params.tokenAmountsToClaim)),
                         _params.nonce,
                         _params.deadline
                     )


### PR DESCRIPTION
### Description

Encode hash of encoded contents of the token claim arrays, as opposed to encoding the arrays directly.

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
