### PR TITLE
VVV-365 investment decimal support

### DIFF
--- a/contracts/tokens/IERC20WithDecimals.sol
+++ b/contracts/tokens/IERC20WithDecimals.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IERC20WithDecimals is IERC20 {
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     */
+    function decimals() external view returns (uint8);
+}

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -35,6 +35,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     /// @notice Environment tag used in the domain separator
     string public environmentTag;
 
+    /// @notice Amount of decimals of the amounts stored in this contract
+    uint8 public decimals = 18;
+
     /// @notice the denominator used to convert units of payment tokens to units of $STABLE (i.e. USDC/T)
     uint256 public immutable exchangeRateDenominator;
 
@@ -291,5 +294,10 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     /// @notice admin function to pause investment
     function setInvestmentIsPaused(bool _isPaused) external onlyAuthorized {
         investmentIsPaused = _isPaused;
+    }
+
+    /// @notice admin function to set decimals value
+    function setDecimals(uint8 _decimals) external onlyAuthorized {
+        decimals = _decimals;
     }
 }

--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -94,7 +94,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
         uint256 exchangeRateNumerator,
         uint256 exchangeRateDenominator,
         uint256 feeNumerator,
-        uint256 investmentAmount
+        uint256 investmentAmount,
+        uint8 paymentTokenDecimals,
+        uint8 ledgerDecimals
     );
 
     /// @notice Error thrown when the input arrays do not have the same length
@@ -206,7 +208,9 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
             _params.exchangeRateNumerator,
             exchangeRateDenominator,
             _params.feeNumerator,
-            postFeeStableAmountEquivalent
+            postFeeStableAmountEquivalent,
+            paymentTokenDecimals,
+            decimals
         );
     }
 
@@ -297,7 +301,17 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
 
             kycAddressInvestedPerRound[kycAddress][investmentRound] += amountToInvest;
             totalInvestedPerRound[investmentRound] += amountToInvest;
-            emit VCInvestment(investmentRound, address(0), kycAddress, 0, 0, 0, amountToInvest);
+            emit VCInvestment(
+                investmentRound,
+                address(0),
+                kycAddress,
+                0,
+                0,
+                0,
+                amountToInvest,
+                decimals,
+                decimals
+            );
         }
     }
 

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -569,7 +569,9 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             params.exchangeRateNumerator,
             LedgerInstance.exchangeRateDenominator(),
             params.feeNumerator,
-            params.amountToInvest * 1e12 - tokenFee * 1e12
+            params.amountToInvest * 1e12 - tokenFee * 1e12,
+            6,
+            LedgerInstance.decimals()
         );
         LedgerInstance.invest(params);
         vm.stopPrank();
@@ -600,7 +602,9 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
                 0,
                 0,
                 0,
-                amountsToInvest[i]
+                amountsToInvest[i],
+                LedgerInstance.decimals(),
+                LedgerInstance.decimals()
             );
         }
         LedgerInstance.addInvestmentRecords(kycAddresses, investmentRounds, amountsToInvest);

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -36,6 +36,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
         bytes4 withdrawSelector = LedgerInstance.withdraw.selector;
         bytes4 addInvestmentRecordsSelector = LedgerInstance.addInvestmentRecords.selector;
         bytes4 setInvestmentPausedSelector = LedgerInstance.setInvestmentIsPaused.selector;
+        bytes4 setDecimalsSelector = LedgerInstance.setDecimals.selector;
         AuthRegistry.setPermission(address(LedgerInstance), withdrawSelector, ledgerManagerRole);
         AuthRegistry.setPermission(
             address(LedgerInstance),
@@ -47,6 +48,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             setInvestmentPausedSelector,
             ledgerManagerRole
         );
+        AuthRegistry.setPermission(address(LedgerInstance), setDecimalsSelector, ledgerManagerRole);
 
         ledgerDomainSeparator = LedgerInstance.computeDomainSeparator();
         investmentTypehash = LedgerInstance.INVESTMENT_TYPEHASH();
@@ -721,6 +723,21 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
         vm.startPrank(sampleUser, sampleUser);
         vm.expectRevert(VVVAuthorizationRegistryChecker.UnauthorizedCaller.selector);
         LedgerInstance.setInvestmentIsPaused(true);
+    }
+
+    /// @notice Tests that an admin can update decimals
+    function testAdminSetDecimals() public {
+        vm.startPrank(ledgerManager, ledgerManager);
+        uint8 newDecimals = 6;
+        LedgerInstance.setDecimals(newDecimals);
+        assertEq(LedgerInstance.decimals(), newDecimals);
+    }
+
+    /// @notice Tests that a non-admin cannot update decimals
+    function testNonAdminSetDecimals() public {
+        vm.startPrank(sampleUser, sampleUser);
+        vm.expectRevert(VVVAuthorizationRegistryChecker.UnauthorizedCaller.selector);
+        LedgerInstance.setDecimals(6);
     }
 
     /// @notice Tests that the domain separator matches reference domain separator

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -76,8 +76,8 @@ abstract contract VVVVCTestBase is Test {
 
     //investment payment tokens
     uint256 paymentTokenMintAmount = 10_000 * 1e6;
-    uint256 userPaymentTokenDefaultAllocation = 10_000 * 1e6;
-    uint256 investmentRoundSampleLimit = 1_000_000 * 1e6;
+    uint256 userPaymentTokenDefaultAllocation = 10_000 * 1e18;
+    uint256 investmentRoundSampleLimit = 1_000_000 * 1e18;
 
     struct TestParams {
         uint256[] investmentRoundIds;


### PR DESCRIPTION
### Description

This feature adds support for payment tokens with various arbitrary decimal counts. Currently a decimal count of 6 is assumed throughout the system but this is error-prone as we do not guarantee this. This PR formalizes the amount of decimals used by the contract and scales the provided amounts as necessary. 

* `InvestParams.kycAddressAllocation` and `InvestParams.investmentRoundLimit` must be given in the correct scale (using the configured `decimals`), this is not and can not be validated
* Extreme care should be taken changing `decimals` whilst investments are ongoing, the assumption is that this isn't something changes frequently.
* The decimal count used by the payment token **cannot** exceed the configured `decimals` count of the ledger. Exceeding decimal counts are rejected, regardless of the validity of the signature.

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
