### PR TITLE
vvv-377-claim-fees-parameter

### DIFF
--- a/contracts/vc/VVVVCTokenDistributor.sol
+++ b/contracts/vc/VVVVCTokenDistributor.sol
@@ -19,7 +19,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
     bytes32 public constant CLAIM_TYPEHASH =
         keccak256(
             bytes(
-                "ClaimParams(address senderAddress,address kycAddress,address projectTokenAddress,address[] projectTokenProxyWallets,uint256[] tokenAmountsToClaim,uint256 nonce,uint256 deadline)"
+                "ClaimParams(address senderAddress,address kycAddress,address projectTokenAddress,address[] projectTokenProxyWallets,uint256[] tokenAmountsToClaim,uint256[] fees,uint256 nonce,uint256 deadline)"
             )
         );
 
@@ -41,6 +41,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
         @param projectTokenAddress Address of the project token to be claimed
         @param projectTokenProxyWallets Array of addresses of the wallets from which the project token is to be claimed
         @param tokenAmountsToClaim Array of amounts of project tokens to claim
+        @param fees Array of fees already deducted from claim amounts
         @param nonce KYC-wallet-based nonce for replay protection
         @param deadline Deadline for signature validity
         @param signature Signature of the user's KYC wallet address
@@ -50,6 +51,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
         address projectTokenAddress;
         address[] projectTokenProxyWallets;
         uint256[] tokenAmountsToClaim;
+        uint256[] fees;
         uint256 nonce;
         uint256 deadline;
         bytes signature;
@@ -61,6 +63,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
         @param projectTokenAddress Address of the project token to be claimed
         @param projectTokenProxyWallets Addresses of the wallets from which the project token is to be claimed
         @param tokenAmountsToClaim Amounts of project tokens claimed from each wallet
+        @param fees Amounts of fees deducted from claim amounts
         @param nonce KYC-wallet-based nonce
      */
     event VCClaim(
@@ -68,6 +71,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
         address indexed projectTokenAddress,
         address[] projectTokenProxyWallets,
         uint256[] tokenAmountsToClaim,
+        uint256[] fees,
         uint256 nonce
     );
 
@@ -101,7 +105,10 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
             revert ClaimIsPaused();
         }
 
-        if (_params.projectTokenProxyWallets.length != _params.tokenAmountsToClaim.length) {
+        if (
+            _params.projectTokenProxyWallets.length != _params.tokenAmountsToClaim.length ||
+            _params.projectTokenProxyWallets.length != _params.fees.length
+        ) {
             revert ArrayLengthMismatch();
         }
 
@@ -133,6 +140,7 @@ contract VVVVCTokenDistributor is VVVAuthorizationRegistryChecker {
             _params.projectTokenAddress,
             _params.projectTokenProxyWallets,
             _params.tokenAmountsToClaim,
+            _params.fees,
             _params.nonce
         );
     }

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -73,6 +73,7 @@ abstract contract VVVVCTestBase is Test {
     uint256[] sampleAmountsToInvest = [1000 * 1e6, 2000 * 1e6, 3000 * 1e6];
     uint256[] sampleTokenAmountsToClaim = [1111 * 1e18, 2222 * 1e18, 3333 * 1e18];
     uint256 sampleTokenAmountToClaim = 6666 * 1e18;
+    uint256[] dummyClaimFees = [11 * 1e18, 22 * 1e18, 33 * 1e18];
 
     //investment payment tokens
     uint256 paymentTokenMintAmount = 10_000 * 1e6;
@@ -262,13 +263,15 @@ abstract contract VVVVCTestBase is Test {
         address _msgSender,
         address _kycAddress,
         address[] memory _projectTokenProxyWallets,
-        uint256[] memory _tokenAmountsToClaim
+        uint256[] memory _tokenAmountsToClaim,
+        uint256[] memory _fees
     ) public view returns (VVVVCTokenDistributor.ClaimParams memory) {
         VVVVCTokenDistributor.ClaimParams memory params = VVVVCTokenDistributor.ClaimParams({
             kycAddress: _kycAddress,
             projectTokenAddress: address(ProjectTokenInstance),
             projectTokenProxyWallets: _projectTokenProxyWallets,
             tokenAmountsToClaim: _tokenAmountsToClaim,
+            fees: _fees,
             nonce: TokenDistributorInstance.nonces(_kycAddress) + 1,
             deadline: block.timestamp + 1 hours,
             signature: bytes("placeholder")

--- a/test/vc/VVVVCTokenDistributor.fuzz.t.sol
+++ b/test/vc/VVVVCTokenDistributor.fuzz.t.sol
@@ -64,7 +64,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
 
         address[] memory projectTokenProxyWallets = new address[](arrayLength);
         uint256[] memory tokenAmountsToClaim = new uint256[](arrayLength);
-
+        uint256[] memory fees = new uint256[](arrayLength);
         uint256 totalClaimAmount = 0;
 
         for (uint256 i = 0; i < arrayLength; i++) {
@@ -74,7 +74,7 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
 
             tokenAmountsToClaim[i] = bound(_seed, 0, 1000 * 1e18);
             totalClaimAmount += tokenAmountsToClaim[i];
-
+            fees[i] = bound(_seed, 0, 100 * 1e18);
             // Mint tokens to the proxy wallet and approve the distributor
             ProjectTokenInstance.mint(projectTokenProxyWallets[i], tokenAmountsToClaim[i]);
             vm.prank(projectTokenProxyWallets[i]);
@@ -87,7 +87,8 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
             _callerAddress,
             _kycAddress,
             projectTokenProxyWallets,
-            tokenAmountsToClaim
+            tokenAmountsToClaim,
+            fees
         );
 
         // Attempt to claim
@@ -114,12 +115,13 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
 
         address[] memory projectTokenProxyWallets = new address[](arrayLength);
         uint256[] memory tokenAmountsToClaim = new uint256[](arrayLength);
-
+        uint256[] memory fees = new uint256[](arrayLength);
         for (uint256 i = 0; i < arrayLength; i++) {
             projectTokenProxyWallets[i] = address(
                 uint160(uint256(keccak256(abi.encodePacked(_callerAddress, i))))
             );
             tokenAmountsToClaim[i] = bound(_seed, 1, 1000 * 1e18);
+            fees[i] = bound(_seed, 0, 100 * 1e18);
             vm.startPrank(projectTokenProxyWallets[i]);
             ProjectTokenInstance.mint(projectTokenProxyWallets[i], tokenAmountsToClaim[i]);
             ProjectTokenInstance.approve(address(TokenDistributorInstance), type(uint256).max);
@@ -130,7 +132,8 @@ contract VVVVCTokenDistributorFuzzTests is VVVVCTestBase {
             _callerAddress,
             _kycAddress,
             projectTokenProxyWallets,
-            tokenAmountsToClaim
+            tokenAmountsToClaim,
+            fees
         );
 
         uint256 testCase = _testCase % 3;

--- a/test/vc/VVVVCTokenDistributor.unit.t.sol
+++ b/test/vc/VVVVCTokenDistributor.unit.t.sol
@@ -68,7 +68,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
         vm.startPrank(sampleUser);
         assertTrue(TokenDistributorInstance.isSignatureValid(claimParams));
@@ -80,7 +81,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleKycAddress,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         claimParams.projectTokenProxyWallets[0] = address(0);
@@ -93,7 +95,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.startPrank(sampleKycAddress);
@@ -105,17 +108,21 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
     function testClaimSingleRound() public {
         address[] memory thisProjectTokenProxyWallets = new address[](1);
         uint256[] memory thisTokenAmountsToClaim = new uint256[](1);
+        uint256[] memory thisFees = new uint256[](1);
 
         thisProjectTokenProxyWallets[0] = projectTokenProxyWallets[0];
 
         uint256 claimAmount = sampleTokenAmountsToClaim[0];
         thisTokenAmountsToClaim[0] = claimAmount;
 
+        thisFees[0] = dummyClaimFees[0];
+
         VVVVCTokenDistributor.ClaimParams memory claimParams = generateClaimParamsWithSignature(
             sampleKycAddress,
             sampleKycAddress,
             thisProjectTokenProxyWallets,
-            thisTokenAmountsToClaim
+            thisTokenAmountsToClaim,
+            thisFees
         );
 
         claimAsUser(sampleKycAddress, claimParams);
@@ -126,18 +133,21 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
     function testClaimZeroAmount() public {
         address[] memory thisProjectTokenProxyWallets = new address[](1);
         uint256[] memory thisTokenAmountsToClaim = new uint256[](1);
-
+        uint256[] memory thisFees = new uint256[](1);
         thisProjectTokenProxyWallets[0] = projectTokenProxyWallets[0];
 
         uint256 claimAmount = 0;
         thisTokenAmountsToClaim[0] = claimAmount;
+
+        thisFees[0] = 0;
 
         //claim for the same single round
         VVVVCTokenDistributor.ClaimParams memory claimParams = generateClaimParamsWithSignature(
             sampleKycAddress,
             sampleKycAddress,
             thisProjectTokenProxyWallets,
-            thisTokenAmountsToClaim
+            thisTokenAmountsToClaim,
+            thisFees
         );
 
         claimAsUser(sampleKycAddress, claimParams);
@@ -150,7 +160,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleKycAddress,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         claimAsUser(sampleKycAddress, claimParams);
@@ -167,7 +178,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleUser,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.startPrank(sampleUser, sampleUser);
@@ -189,7 +201,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.expectRevert(VVVVCTokenDistributor.InvalidSignature.selector);
@@ -202,7 +215,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         claimParams.projectTokenAddress = address(0);
@@ -216,7 +230,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         claimParams.nonce = 0;
@@ -233,7 +248,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             shorterProxyWalletArray,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.expectRevert(VVVVCTokenDistributor.ArrayLengthMismatch.selector);
@@ -246,7 +262,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleUser,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.startPrank(tokenDistributorManager);
@@ -265,7 +282,8 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             sampleUser,
             sampleKycAddress,
             projectTokenProxyWallets,
-            sampleTokenAmountsToClaim
+            sampleTokenAmountsToClaim,
+            dummyClaimFees
         );
 
         vm.startPrank(sampleUser, sampleUser);
@@ -275,6 +293,7 @@ contract VVVVCTokenDistributorUnitTests is VVVVCTestBase {
             address(ProjectTokenInstance),
             projectTokenProxyWallets,
             sampleTokenAmountsToClaim,
+            dummyClaimFees,
             claimParams.nonce
         );
         TokenDistributorInstance.claim(claimParams);


### PR DESCRIPTION
### Description

- Add `uint256[]` fees to `ClaimParams`
- Add `uint256[]` fees to `CLAIM_TYPEHASH`
- Add `uint256[]` fees to `VCClaim`
- Add array length check for `fees`
- Modified tests to suit this addition

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
