### PR TITLE
vvv-401-fix-fee-calculation-logic-in-vvvvcinvestmentledger-contract

### DIFF
--- a/contracts/vc/test.sol
+++ b/contracts/vc/test.sol
@@ -55,7 +55,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
      * @param investmentRoundEndTimestamp The end timestamp of the investment round
      * @param paymentTokenAddress The address of the payment token
      * @param kycAddress The address of the kyc address
-     * @param kycAddressAllocation The max amount the kyc address can invest (post-conversion to stablecoin terms)
+     * @param kycAddressAllocation The max amount the kyc address can invest
      * @param amountToInvest The amount of paymentToken to invest
      * @param exchangeRateNumerator The numerator of the conversion of payment token to stablecoin (i.e. VVV to USDC)
      * @param feeNumerator The numerator of the fee subtracted from the investment stable-equivalent amount

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -76,7 +76,7 @@ abstract contract VVVVCTestBase is Test {
     uint256[] dummyClaimFees = [11 * 1e18, 22 * 1e18, 33 * 1e18];
 
     //investment payment tokens
-    uint256 paymentTokenMintAmount = 10_000 * 1e6;
+    uint256 paymentTokenMintAmount = 11_000 * 1e6;
     uint256 userPaymentTokenDefaultAllocation = 10_000 * 1e18;
     uint256 investmentRoundSampleLimit = 1_000_000 * 1e18;
 
@@ -201,7 +201,7 @@ abstract contract VVVVCTestBase is Test {
 
     function investAsUser(address _investor, VVVVCInvestmentLedger.InvestParams memory _params) public {
         vm.startPrank(_investor, _investor);
-        PaymentTokenInstance.approve(address(LedgerInstance), _params.amountToInvest);
+        PaymentTokenInstance.approve(address(LedgerInstance), type(uint256).max);
         LedgerInstance.invest(_params);
         vm.stopPrank();
     }


### PR DESCRIPTION
### Description

in `VVVVCInvestmentLedger.sol` instead of 100 -> (90 invested, 10 fee), implement 110 -> (100 invested, 10 fee), update tests accordingly

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [x] Bug fix
- [ ] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed
