### PR TITLE
vvv-412-sign-msgsender-in-investment-ledger

### DIFF
--- a/contracts/vc/VVVVCInvestmentLedger.sol
+++ b/contracts/vc/VVVVCInvestmentLedger.sol
@@ -19,7 +19,7 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
     bytes32 public constant INVESTMENT_TYPEHASH =
         keccak256(
             bytes(
-                "InvestParams(uint256 investmentRound,uint256 investmentRoundLimit,uint256 investmentRoundStartTimestamp,uint256 investmentRoundEndTimestamp,address paymentTokenAddress,address kycAddress,uint256 kycAddressAllocation,uint256 amountToInvest,uint256 exchangeRateNumerator,uint256 feeNumerator,uint256 deadline)"
+                "InvestParams(uint256 investmentRound,uint256 investmentRoundLimit,uint256 investmentRoundStartTimestamp,uint256 investmentRoundEndTimestamp,address paymentTokenAddress,address kycAddress,uint256 kycAddressAllocation,uint256 exchangeRateNumerator,uint256 feeNumerator,uint256 deadline,address sender)"
             )
         );
 
@@ -250,10 +250,10 @@ contract VVVVCInvestmentLedger is VVVAuthorizationRegistryChecker {
                         _params.paymentTokenAddress,
                         _params.kycAddress,
                         _params.kycAddressAllocation,
-                        _params.amountToInvest,
                         _params.exchangeRateNumerator,
                         _params.feeNumerator,
-                        _params.deadline
+                        _params.deadline,
+                        msg.sender
                     )
                 )
             )

--- a/test/vc/VVVVCInvestmentLedger.fuzz.sol
+++ b/test/vc/VVVVCInvestmentLedger.fuzz.sol
@@ -62,7 +62,12 @@ contract VVVVCInvestmentLedgerFuzzTests is VVVVCTestBase {
             signature: bytes("placeholder")
         });
 
-        params.signature = getEIP712SignatureForInvest(ledgerDomainSeparator, investmentTypehash, params);
+        params.signature = getEIP712SignatureForInvest(
+            ledgerDomainSeparator,
+            investmentTypehash,
+            sampleUser,
+            params
+        );
 
         //check that the investment ledger state is updated correctly given these conditions,
         //which should yield successful investments

--- a/test/vc/VVVVCInvestmentLedger.unit.t.sol
+++ b/test/vc/VVVVCInvestmentLedger.unit.t.sol
@@ -79,9 +79,12 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
+
+        vm.prank(sampleUser);
         assertTrue(LedgerInstance.isSignatureValid(params));
     }
 
@@ -98,6 +101,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -105,6 +109,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
         //round start timestamp is off by one second
         params.investmentRoundStartTimestamp += 1;
 
+        vm.prank(sampleUser);
         assertFalse(LedgerInstance.isSignatureValid(params));
     }
 
@@ -121,6 +126,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -134,6 +140,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateDenominator
         );
 
+        vm.prank(sampleUser);
         assertFalse(newLedger.isSignatureValid(params));
     }
 
@@ -149,6 +156,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -156,6 +164,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
         // Advance time past the deadline of 1 hour
         advanceBlockNumberAndTimestampInSeconds(1 hours + 2);
 
+        vm.prank(sampleUser);
         assertFalse(LedgerInstance.isSignatureValid(params));
     }
 
@@ -169,6 +178,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -176,6 +186,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
         // change amountToInvest to be +1
         params.amountToInvest += 1;
 
+        vm.prank(sampleUser);
         assertFalse(LedgerInstance.isSignatureValid(params));
     }
 
@@ -192,6 +203,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -224,6 +236,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -249,6 +262,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -269,6 +283,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             newExchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -302,6 +317,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -332,6 +348,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             block.timestamp + 1 days,
             block.timestamp + 2 days
         );
@@ -356,6 +373,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             block.timestamp - 2 days,
             block.timestamp - 1 days
         );
@@ -380,6 +398,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -413,6 +432,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -440,6 +460,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -465,6 +486,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -502,6 +524,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -530,6 +553,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );
@@ -709,6 +733,7 @@ contract VVVVCInvestmentLedgerUnitTests is VVVVCTestBase {
             exchangeRateNumerator,
             feeNumerator,
             sampleKycAddress,
+            sampleUser,
             activeRoundStartTimestamp,
             activeRoundEndTimestamp
         );

--- a/test/vc/VVVVCTestBase.sol
+++ b/test/vc/VVVVCTestBase.sol
@@ -135,6 +135,7 @@ abstract contract VVVVCTestBase is Test {
     function getEIP712SignatureForInvest(
         bytes32 _domainSeparator,
         bytes32 _investmentTypehash,
+        address _sender,
         VVVVCInvestmentLedger.InvestParams memory _params
     ) public view returns (bytes memory) {
         bytes32 digest = keccak256(
@@ -151,10 +152,10 @@ abstract contract VVVVCTestBase is Test {
                         _params.paymentTokenAddress,
                         _params.kycAddress,
                         _params.kycAddressAllocation,
-                        _params.amountToInvest,
                         _params.exchangeRateNumerator,
                         _params.feeNumerator,
-                        _params.deadline
+                        _params.deadline,
+                        _sender
                     )
                 )
             )
@@ -174,6 +175,7 @@ abstract contract VVVVCTestBase is Test {
         uint256 _exchangeRateNumerator,
         uint256 _feeNumerator,
         address _kycAddress,
+        address _sender,
         uint256 _investmentRoundStartTimestamp,
         uint256 _investmentRoundEndTimestamp
     ) public view returns (VVVVCInvestmentLedger.InvestParams memory) {
@@ -192,7 +194,12 @@ abstract contract VVVVCTestBase is Test {
             signature: bytes("placeholder")
         });
 
-        bytes memory sig = getEIP712SignatureForInvest(ledgerDomainSeparator, investmentTypehash, params);
+        bytes memory sig = getEIP712SignatureForInvest(
+            ledgerDomainSeparator,
+            investmentTypehash,
+            _sender,
+            params
+        );
 
         params.signature = sig;
 
@@ -221,6 +228,7 @@ abstract contract VVVVCTestBase is Test {
                 exchangeRateNumerator,
                 feeNumerator,
                 sampleKycAddress,
+                _investor,
                 block.timestamp,
                 block.timestamp + 1 days
             );


### PR DESCRIPTION
### Description

Modifying `VVVVCInvestmentLedger` to sign msg.sender instead of amountToInvest

### Related Issue (if applicable)

Mention any related issues here.

### Type of Change

- [ ] Bug fix
- [x] New feature

### Checklist

- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests passed
